### PR TITLE
Add authentication plugins with matching configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   # Upgrade Docker to work with docker-py.
-  - curl https://gist.githubusercontent.com/geerlingguy/ce883ad4aec6a5f1187ef93bd338511e/raw/36612d28981d92863f839c5aefe5b7dd7193d6c6/travis-ci-docker-upgrade.sh | sudo bash
+  - curl https://gist.githubusercontent.com/geerlingguy/ce883ad4aec6a5f1187ef93bd338511e/raw/36612d28981d92863f839c5aefe5b7dd7193d6c6/travis-ci-docker-upgrade.sh | sudo bash # yamllint disable-line
 
 install:
   # Install test dependencies.
@@ -34,4 +34,3 @@ script:
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
-  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,13 +2,22 @@
 verdaccio_version: ''
 verdaccio_configdir: '/home/verdaccio/verdaccio'
 verdaccio_datadir: '/home/verdaccio/verdaccio'
+verdaccio_plugins:    # Must be a list of name/version for the plugins
+# For example:
+#  - name: verdaccio-ldap
+#    version: 4.2.0
+#  - name: verdaccio-groupnames
+#    version: 1.0.4-1
+verdaccio_pluginsdir: "{{verdaccio_datadir}}/plugins"
 verdaccio_web_title: 'Verdaccio'
 verdaccio_web_gravatar: false
 verdaccio_web_sort_packages: asc
 verdaccio_listen_address: 0.0.0.0
 verdaccio_listen_port: 4873
-verdaccio_authenticate_file_location: "{{ verdaccio_datadir }}/htpasswd"
-verdaccio_authenticate_max_users: +inf
+verdaccio_auth:
+  htpasswd:
+    file: "{{ verdaccio_datadir }}/htpasswd"
+    max_users: +inf
 
 verdaccio_uplinks:
   npmjs:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,14 @@
     global: true
   notify: restart verdaccio
 
+- name: verdaccio plugins installed
+  npm:
+    name: "{{ item.name }}"
+    version: "{{ item.version | default(omit) }}"
+    path: "{{ verdaccio_pluginsdir }}"
+  with_items: "{{ verdaccio_plugins }}"
+  when: verdaccio_plugins is not none
+
 - name: verdaccio user created
   user:
     name: verdaccio
@@ -21,12 +29,13 @@
   when: >
     (npm_config_prefix_resolve.rc == 0) and
     ("FAILED" not in npm_config_prefix_resolve.stderr) and
-    (npm_config_prefix_resolve.stdout != '')
+    (npm_config_prefix_resolve.stdout | length > 0)
 
 - name: deploy verdaccio systemd unit
   template:
     src: verdaccio.service.j2
     dest: /etc/systemd/system/verdaccio.service
+    mode: 0600
   notify: systemd daemon-reload
 
 - name: verdaccio service enabled
@@ -39,6 +48,7 @@
     path: "{{ item }}"
     state: directory
     owner: verdaccio
+    mode: 0755
   loop:
     - "{{ verdaccio_datadir }}"
     - "{{ verdaccio_configdir }}"
@@ -48,6 +58,7 @@
     src: config.j2
     dest: "{{ verdaccio_configdir }}/verdaccio.yml"
     owner: verdaccio
+    mode: 0600
   notify: restart verdaccio
 
 - name: install logrotate script

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -18,11 +18,7 @@ web:
   sort_packages: {{ verdaccio_web_sort_packages }}
 
 auth:
-  htpasswd:
-    file: {{ verdaccio_authenticate_file_location }}
-    # Maximum amount of users allowed to register, defaults to "+inf".
-    # You can set this to -1 to disable registration.
-    max_users: {{ verdaccio_authenticate_max_users }}
+  {{ verdaccio_auth | to_nice_yaml(width=80, indent=2) | indent(2) }}
 
 # a list of other known repositories we can talk to
 uplinks:


### PR DESCRIPTION
Hello,

I found that the role was lacking the possibility of setting different authentication plugin for verdaccio.
This PR allows to install a list of plugins and setup authentication block.
There are also minor ansible-lint and yamllint fixes.

Feel fee to give any necessary feedback.

Maxime